### PR TITLE
feat(workflows): Add intermediate and final state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # @node-ts/bus-starter
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/node-ts/bus-starter.svg)](https://greenkeeper.io/) [![CircleCI](https://circleci.com/gh/node-ts/bus-starter/tree/master.svg?style=svg)](https://circleci.com/gh/node-ts/bus-starter/tree/master) [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT) 
+[![Greenkeeper badge](https://badges.greenkeeper.io/node-ts/bus-starter.svg)](https://greenkeeper.io/) [![CircleCI](https://circleci.com/gh/node-ts/bus-starter/tree/master.svg?style=svg)](https://circleci.com/gh/node-ts/bus-starter/tree/master) [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 A starter project for @node-ts/bus for building distributed message based systems with node.
 
 ## Why?
 
-[@node-ts/bus](https://node-ts.github.io/bus/) is focussed on helping build distributed systems in node based on messaging patterns that are reliable, scalable and fault tolerant. Applications built this way can:
+[@node-ts/bus](https://node-ts.github.io/bus/) is focused on helping build distributed systems in node based on messaging patterns that are reliable, scalable and fault tolerant. Applications built this way can:
 
 * survive restarts and downtime
 * handle bursty loads
 * scale in and out easily
-* survive network interuptions
+* survive network interruptions
 * tolerate external API outages
 * easily be refactored from monolith to microservice
 
 All without losing data. This makes message based systems a great choice where reliability and data integrity is key.
 
-However, building distributed message based applications isn't simple. At its heart, this project uses the service bus from [@node-ts/bus](https://node-ts.github.io/bus/) that encapsulates many of the complexities when dealing with messaging technologies and approaches. 
+However, building distributed message based applications isn't simple. At its heart, this project uses the service bus from [@node-ts/bus](https://node-ts.github.io/bus/) that encapsulates many of the complexities when dealing with messaging technologies and approaches.
 
 Your code stays cleaner, as only business logic related code needs to be written. Concerns on how a message is dispatched, routed, received, processed, retried etc are all handled by the underlying framework. This remains true regardless if the app operates in a single process in memory, or runs with many services and instances across many compute instances.
 
@@ -56,7 +56,7 @@ At this point you can remove the existing messages/handlers/workflows and start 
 * install a [durable transport](https://node-ts.github.io/bus/packages/bus-core/src/transport/)
 * install a [durable persistence](https://node-ts.github.io/bus/packages/bus-workflow/src/workflow/persistence/)
 
-These steps are crucial to ensuring your appliation is resilient and scalable
+These steps are crucial to ensuring your application is resilient and scalable
 
 ## Scripts
 
@@ -70,7 +70,7 @@ The following scripts are available as part of the starter project:
 
 ## Running
 
-A small implementation of a distributed application has been made to demonstrate a generic project structure. This should be removed and replaced with your implementation. 
+A small implementation of a distributed application has been made to demonstrate a generic project structure. This should be removed and replaced with your implementation.
 
 The example used is testing sirens for correct operation (such as in a building fire alarm test). When a siren is tested, it publishes an event depending on success or failure. If a failure event is published, a workflow coordinates the sending of an email to the maintenance team to fix the siren.
 

--- a/src/workflows/siren-test-workflow.ts
+++ b/src/workflows/siren-test-workflow.ts
@@ -1,6 +1,6 @@
 import { Workflow, StartedBy, Handles } from '@node-ts/bus-workflow'
 import { SirenTestWorkflowData } from './sirent-test-workflow-data'
-import { SirenTestStarted, SirenTestFailed, EmailMaintenanceTeam, MaintenanceTeamEmailed } from '../messages'
+import { SirenTestStarted, SirenTestFailed, SirenTestPassed, EmailMaintenanceTeam, MaintenanceTeamEmailed } from '../messages'
 import { inject } from 'inversify'
 import { BUS_SYMBOLS, Bus } from '@node-ts/bus-core'
 
@@ -30,6 +30,15 @@ export class SirenTestWorkflow extends Workflow<SirenTestWorkflowData> {
       sirenId
     )
     await this.bus.send(emailMaintenanceTeam)
+    return {}
+  }
+
+  @Handles<SirenTestPassed, SirenTestWorkflowData, 'handlesSirenTestPassed'>(
+    SirenTestPassed,
+    event => event.sirenId,
+    'sirenId'
+  )
+  async handlesSirenTestPassed (_: SirenTestPassed): Promise<Partial<SirenTestWorkflowData>> {
     return this.complete()
   }
 
@@ -39,7 +48,9 @@ export class SirenTestWorkflow extends Workflow<SirenTestWorkflowData> {
     'sirenId'
   )
   async handlesMaintenanceTeamEmailed (_: MaintenanceTeamEmailed): Promise<Partial<SirenTestWorkflowData>> {
-    return this.complete()
+    return this.complete({
+      maintenanceEmailSent: true
+    })
   }
 
 }

--- a/src/workflows/sirent-test-workflow-data.ts
+++ b/src/workflows/sirent-test-workflow-data.ts
@@ -5,4 +5,5 @@ export class SirenTestWorkflowData extends WorkflowData {
   $name = 'bus-starter/siren-test-data'
 
   sirenId: Uuid
+  maintenanceEmailSent: boolean
 }


### PR DESCRIPTION
- Handler for `SirenTestFailed` should not invoke `complete`, rather should return intermediate state until `MaintenanceTeamEmailed` completes workflow (https://github.com/node-ts/bus-starter/commit/832e568f06e64bb9cd07070e38ac807b5ff8ec2c#diff-f7c43a6aa0a82592ce1e07ed114e8a97R33)

- Handler for `MaintenanceTeamEmailed` updates workflow state to demonstrate passing state update to `complete` method (https://github.com/node-ts/bus-starter/commit/832e568f06e64bb9cd07070e38ac807b5ff8ec2c#diff-f7c43a6aa0a82592ce1e07ed114e8a97R51)

- Adds simple handler for `SirenTestPassed` (https://github.com/node-ts/bus-starter/commit/832e568f06e64bb9cd07070e38ac807b5ff8ec2c#diff-f7c43a6aa0a82592ce1e07ed114e8a97R41)