### PR TITLE
Rabbit MQ dead letter queue example

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@node-ts/bus-core": "^0.5.1",
     "@node-ts/bus-messages": "^0.2.1",
-    "@node-ts/bus-rabbitmq": "^0.4.1",
+    "@node-ts/bus-rabbitmq": "^0.5.0",
     "@node-ts/bus-workflow": "^0.5.1",
     "@node-ts/logger-core": "^0.1.0",
     "@node-ts/logger-winston": "^0.1.0",

--- a/src/application-container.ts
+++ b/src/application-container.ts
@@ -4,16 +4,25 @@ import { LoggerModule } from '@node-ts/logger-core'
 import { WinstonModule } from '@node-ts/logger-winston'
 import { HandlersModule } from './handlers/handlers-module'
 import { BusWorkflowModule } from '@node-ts/bus-workflow'
+import {
+  BUS_RABBITMQ_SYMBOLS,
+  BusRabbitMqModule,
+  RabbitMqTransportConfiguration
+} from '@node-ts/bus-rabbitmq'
 
-export class ApplicationContainer extends Container {
-  constructor () {
-    super()
-    this.load(
-      new LoggerModule(),
-      new WinstonModule(),
-      new BusModule(),
-      new BusWorkflowModule(),
-      new HandlersModule()
-    )
-  }
+const rabbitConfiguration: RabbitMqTransportConfiguration = {
+  queueName: 'accounts-application-queue',
+  connectionString: 'amqp://guest:guest@localhost'
 }
+
+export const container = new Container()
+container.load(new LoggerModule())
+container.load(new BusModule())
+container.load(new BusRabbitMqModule())
+container.load(new WinstonModule())
+container.load(new BusWorkflowModule())
+container.load(new HandlersModule())
+
+container
+  .bind(BUS_RABBITMQ_SYMBOLS.TransportConfiguration)
+  .toConstantValue(rabbitConfiguration)

--- a/src/handlers/start-siren-test-handler.ts
+++ b/src/handlers/start-siren-test-handler.ts
@@ -10,26 +10,8 @@ const TEST_FAILURE_THRESHOLD = 0.5
 @HandlesMessage(StartSirenTest)
 export class StartSirenTestHandler {
 
-  constructor (
-    @inject(BUS_SYMBOLS.Bus) private readonly bus: Bus,
-    @inject(LOGGER_SYMBOLS.Logger) private readonly logger: Logger
-  ) {
+  async handle (_: StartSirenTest): Promise<void> {
+    throw new Error('Command will be routed to the DLQ after retries are exhausted')
   }
 
-  async handle ({ sirenId }: StartSirenTest): Promise<void> {
-    this.logger.info('StartSirenTest command received, starting siren test...', { sirenId })
-    setTimeout(async () => testSiren(this.bus, this.logger, sirenId), MAX_SIREN_TEST_DURATION)
-    await this.bus.publish(new SirenTestStarted(sirenId))
-  }
-
-}
-
-async function testSiren (bus: Bus, logger: Logger, sirenId: Uuid): Promise<void> {
-  const testFailed = Math.random() > TEST_FAILURE_THRESHOLD
-  logger.info('Siren test completed, publishing event', { sirenId, testFailed })
-  if (testFailed) {
-    await bus.publish(new SirenTestFailed(sirenId))
-  } else {
-    await bus.publish(new SirenTestPassed(sirenId))
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { ApplicationContainer } from './application-container'
+import { container } from './application-container'
 import { BUS_SYMBOLS, Bus, ApplicationBootstrap } from '@node-ts/bus-core'
 import { generateUuid } from './messages/uuid'
 import { WINSTON_SYMBOLS } from '@node-ts/logger-winston'
@@ -11,7 +11,6 @@ import { StartSirenTestHandler, EmailMaintenanceTeamHandler } from './handlers'
 import { WorkflowRegistry, BUS_WORKFLOW_SYMBOLS } from '@node-ts/bus-workflow'
 import { SirenTestWorkflowData, SirenTestWorkflow } from './workflows'
 
-const container = new ApplicationContainer()
 container.rebind(WINSTON_SYMBOLS.WinstonConfiguration).to(LoggerConfiguration)
 
 async function initialize (): Promise<void> {


### PR DESCRIPTION
This demonstrates the retry + DLQ routing using Rabbit MQ as a transport. This was released in `@node-ts/bus-rabbitmq:0.5.0`, with the number of retries configurable in `RabbitMqTransportConfiguration.maxRetries`