### PR TITLE
Fixing a bug in the starter until the workflow is correctly construct…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -714,6 +714,11 @@
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "dev": true
     },
+    "inversify": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-4.13.0.tgz",
+      "integrity": "sha512-O5d8y7gKtyRwrvTLZzYET3kdFjqUy58sGpBYMARF13mzqDobpfBXVOPLH7HmnD2VR6Q+1HzZtslGvsdQfeb0SA=="
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@node-ts/bus-core": "^1.0.0",
     "@node-ts/bus-messages": "^1.0.0",
     "@node-ts/bus-rabbitmq": "^1.0.1",
+    "inversify": "^4.13.0",
     "reflect-metadata": "^0.1.13",
     "uuid": "^7.0.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import 'reflect-metadata'
 
-import { Bus, BusInstance } from '@node-ts/bus-core'
+import { Bus, BusInstance, Workflow } from '@node-ts/bus-core'
 import { generateUuid } from './messages/uuid'
 
 import { StartSirenTest } from './messages'
 import { startSirenTestHandler, emailMaintenanceTeamHandler } from './handlers'
 import { SirenTestWorkflow } from './workflows'
 import { RabbitMqTransportConfiguration, RabbitMqTransport } from '@node-ts/bus-rabbitmq'
+import { Container, decorate, inject, injectable } from 'inversify'
 
 const rabbitMqConfiguration: RabbitMqTransportConfiguration = {
   queueName: '@node-ts/bus-starter-test',
@@ -16,14 +17,59 @@ const rabbitMqConfiguration: RabbitMqTransportConfiguration = {
 
 const rabbitMq = new RabbitMqTransport(rabbitMqConfiguration)
 
+// Temporarily adding in a container to fix undefined bus in SirenTestWorkflow
+/*
+
+  @node-ts/bus-core:service-bus Message was unsuccessfully handled. Returning to queue {
+  message: {
+    id: '20f86b65-4831-4231-b3b3-025a42bb6d11',
+    domainMessage: SirenTestFailed {
+      sirenId: '3d963824-ff8e-43dd-9e09-62cf15dbdff7',
+      '$name': 'bus-starter/siren-test-failed',
+      '$version': 0
+    },
+    raw: {
+      fields: [Object],
+      properties: [Object],
+      content: <Buffer 7b 22 73 69 72 65 6e 49 64 22 3a 22 33 64 39 36 33 38 32 34 2d 66 66 38 65 2d 34 33 64 64 2d 39 65 30 39 2d 36 32 63 66 31 35 64 62 64 66 66 37 22 2c ... 53 more bytes>
+    },
+    attributes: {
+      correlationId: '2c7ce8c6-6163-4bda-a525-b3840228b84d',
+      attributes: {},
+      stickyAttributes: {}
+    }
+  },
+  error: {
+    name: 'TypeError',
+    message: "Cannot read property 'send' of undefined",
+    stack: "TypeError: Cannot read property 'send' of undefined\n" +
+      '    at SirenTestWorkflow.handlesSirenTestFailed (/Users/russwatson/projects/clients/bakerstreet/bus-starter/dist/workflows/siren-test-workflow.js:36:24)\n' +
+      '    at WorkflowRegistry.dispatchMessageToWorkflow (/Users/russwatson/projects/clients/bakerstreet/bus-starter/node_modules/@node-ts/bus-core/dist/workflow/registry/workflow-registry.js:184:65)\n' +
+      '    at /Users/russwatson/projects/clients/bakerstreet/bus-starter/node_modules/@node-ts/bus-core/dist/workflow/registry/workflow-registry.js:143:36\n' +
+      '    at Array.map (<anonymous>)\n' +
+      '    at /Users/russwatson/projects/clients/bakerstreet/bus-starter/node_modules/@node-ts/bus-core/dist/workflow/registry/workflow-registry.js:140:56'
+  }
+} +2ms
+
+*/
+
+decorate(injectable(), SirenTestWorkflow);
+decorate(inject("bus"), SirenTestWorkflow, 0);
+decorate(injectable(), Workflow);
+
 let bus: BusInstance
 async function initialize (): Promise<void> {
+  const container = new Container();
   bus = await Bus.configure()
+    .withContainer(container)
     .withWorkflow(SirenTestWorkflow)
     .withHandler(startSirenTestHandler(() => bus)) // Late bound so it's available at runtime
     .withHandler(emailMaintenanceTeamHandler(() =>bus))
     .withTransport(rabbitMq)
     .initialize()
+
+  container.bind(SirenTestWorkflow).to(SirenTestWorkflow);
+  container.bind("bus").toConstantValue(bus);
 
   await bus.start()
 }


### PR DESCRIPTION
We were getting ready to write an enterprise bus messaging queue from scratch because we didn't think anything existed for TS already, but we were excited to find `node-ts/*`!

Anyway, we saw that you recently removed InversifyJS as a hard dependency. Sad, but I understand the reasoning (We just InversifyJS extensively). The removal caused an issue with the starter, so I temporarily setup the bus with a container using Inversify in main until you guys work out how to get a bus instance to the workflows internally.